### PR TITLE
Generate a live report with an exception object to support caught exception logging

### DIFF
--- a/Source/PLCrashReporter.h
+++ b/Source/PLCrashReporter.h
@@ -122,9 +122,11 @@ typedef struct PLCrashReporterCallbacks {
 
 - (NSData *) generateLiveReportWithThread: (thread_t) thread;
 - (NSData *) generateLiveReportWithThread: (thread_t) thread error: (NSError **) outError;
+- (NSData *) generateLiveReportWithThread: (thread_t) thread exception: (NSException *) exception error: (NSError **) outError;
 
 - (NSData *) generateLiveReport;
 - (NSData *) generateLiveReportAndReturnError: (NSError **) outError;
+- (NSData *) generateLiveReportWithException: (NSException *) exception error: (NSError **) outError;
 
 - (BOOL) purgePendingCrashReport;
 - (BOOL) purgePendingCrashReportAndReturnError: (NSError **) outError;


### PR DESCRIPTION
We've been using these changes for over a year now with a modified version of HockeySDK, and it's been working very well for us. We'd like to contribute this to plcrashreporter so that we can also contribute the exception reporting back to Hockey App too.

I tried using https://opensource.plausible.coop to propose this, but there seem to be authentication issues preventing me from signing into my account (password reset also errors) or creating a new one.